### PR TITLE
docs: Modifications/Suggestions from the Platforms Team

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,8 +287,8 @@ Please be pragmatic, and consider the cost of each incremental request for chang
 - You’ll often catch code mistakes you didn’t see when writing it.
 - This is also a good time to leave comments and refresh your memory in order to write a more helpful description.
 
-### Assign no more than 1-3 reviewers
-- It’s tempting to want to involve as many people as possible, but it can often be distracting, and create a situation where nobody’s clear on who should actually perform the review.
+### Assign Relevant for Review 
+- To ensure the correct people get their eyes on the PR, please request the review of the respective team to review the PR
 - If your work spans multiple teams (and thus, many reviewers), consider breaking up your PR into multiple compatible patches (e.g. a back-end change and a front-end change).
 
 ### Avoid rebasing unnecessarily


### PR DESCRIPTION
Just some updates in regards to formatting, wording, etc. As well we are gonna remove the requirement to assign individuals and instead aim for assigning GitHub teams, that allows external contributors to assign it so we internally get a notification that a submission has been made without the chance that a single person gets requested for reviews only.