### PR TITLE
docs: Add Details About Comment Resolution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,6 +302,7 @@ Please be pragmatic, and consider the cost of each incremental request for chang
 
 - Request review again via the "Reviewers" dropdown (There should be a yellow dot next to their name again).
 - Don’t rely on reviewers' mind-reading skills to know that you’re ready to have them look things over again.
+- Leave comment resolution to the reviewer so they can easily reference sections that you have addressed.
 
 [Return to top](#contributing)
 
@@ -325,5 +326,6 @@ Please be pragmatic, and consider the cost of each incremental request for chang
 
 - We recommend checking for open code reviews at the start and end of every day.
 - [Github's Review Requests tab](https://github.com/pulls/review-requested) can be a helpful place to keep track of these.
+- Resolve comments when submitter has resolved the issue.
 
 [Return to top](#contributing)


### PR DESCRIPTION
So when comments are resolved in PRs they no longer appear for the reviewer in the code view, this can cause challenges for the reviewer as the whole file expands designating that it's changed, but pin-pointing the exact position of the change can be hard. 

This proposal would be to encourage the reviewer to resolve comments when they have been addressed over the submitter so the comments are still present during code review as well, if the changes made to address the issue need further discussion having the same comment thread can provide better overall context.